### PR TITLE
ci: fix publish-folder-path

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 = Traffic Shadowing
 
 ifdef::env-github[]
-image:https://img.shields.io/static/v1?label=Available%20at&message=Gravitee.io&color=1EC9D2["Gravitee.io", link="https://download.gravitee.io/#y/gravitee-policy-traffic-shadowing/"]
+image:https://img.shields.io/static/v1?label=Available%20at&message=Gravitee.io&color=1EC9D2["Gravitee.io", link="https://download.gravitee.io/#graviteeio-apim/plugins/policies/gravitee-policy-traffic-shadowing/"]
 image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License", link="https://github.com/gravitee-io/gravitee-policy-traffic-shadowing/blob/master/LICENSE.txt"]
 image:https://img.shields.io/badge/semantic--release-conventional%20commits-e10079?logo=semantic-release["Releases", link="https://github.com/gravitee-io/gravitee-policy-traffic-shadowing/releases"]
 image:https://circleci.com/gh/gravitee-io/gravitee-policy-traffic-shadowing.svg?style=svg["CircleCI", link="https://circleci.com/gh/gravitee-io/gravitee-policy-traffic-shadowing"]

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <gravitee-common.version>1.18.0</gravitee-common.version>
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
-        <publish-folder-path>y</publish-folder-path>
+        <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
 
     <dependencies>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-traffic-shadowing/1.2.0/gravitee-policy-traffic-shadowing-1.2.0.zip)
  <!-- Version placeholder end -->
