### PR TITLE
adapt policy to APIM 3.15+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +32,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/README.adoc
+++ b/README.adoc
@@ -27,6 +27,15 @@ endif::[]
 
 Traffic shadowing allows to asynchronously copy the traffic to another service. By using this policy, the requests are duplicated and sent to the target. The target is an endpoint defined at the API level. The request can be enriched with additional headers.
 
+== Compatibility with APIM
+
+|===
+| Plugin version | APIM version
+
+| 2.x and upper  | 3.15.x to latest
+| Up to 1.1.x    | Up to 3.14.x
+|===
+
 == Configuration
 
 |===
@@ -52,7 +61,7 @@ Traffic shadowing allows to asynchronously copy the traffic to another service. 
 ----
 {
   "traffic-shadowing": {
-    "target": "{#endpoint['target-endpoint']}",
+    "target": "{#endpoints['target-endpoint']}",
     "headers": [
         {
             "name": "X-Gravitee-Request-Id",

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-traffic-shadowing</artifactId>
-    <version>1.1.0</version>
+    <version>2.0.0-adapt-3-15-x-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Policy - Traffic Shadowing</name>
     <description>Description of the Traffic Shadowing Gravitee Policy</description>
@@ -31,17 +31,36 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>19.2.1</version>
+        <version>21.0.0</version>
     </parent>
 
     <properties>
-        <gravitee-gateway-api.version>1.25.0</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.18.0</gravitee-common.version>
-        <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
+        <gravitee-bom.version>3.0.0</gravitee-bom.version>
+        <gravitee-gateway-api.version>2.0.1</gravitee-gateway-api.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
+        <gravitee-common.version>2.0.0</gravitee-common.version>
+        <gravitee-gateway.version>3.20.1</gravitee-gateway.version>
+
+        <maven-assembly-plugin.version>3.4.2</maven-assembly-plugin.version>
+        <prettier-maven-plugin.version>0.19</prettier-maven-plugin.version>
+        <properties-maven-plugin.version>1.1.0</properties-maven-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Gravitee dependencies -->
+            <!-- Import bom to properly inherit all dependencies -->
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- Provided scope -->
@@ -69,14 +88,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>${spring.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -84,7 +101,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -100,6 +116,13 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
+            <version>${gravitee-gateway.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -113,7 +136,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <version>${properties-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>initialize</phase>
@@ -150,21 +173,12 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8</version>
-                <configuration>
-                    <additionalOptions>-Xdoclint:none</additionalOptions>
-                    <source>8</source>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.12</version>
+                <version>${prettier-maven-plugin.version}</version>
                 <configuration>
                     <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.0.1</prettierJavaVersion>
+                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/io/gravitee/policy/trafficshadowing/TrafficShadowingPolicy.java
+++ b/src/main/java/io/gravitee/policy/trafficshadowing/TrafficShadowingPolicy.java
@@ -15,17 +15,20 @@
  */
 package io.gravitee.policy.trafficshadowing;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.endpoint.resolver.EndpointResolver;
 import io.gravitee.gateway.api.endpoint.resolver.ProxyEndpoint;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.proxy.ProxyConnection;
 import io.gravitee.gateway.api.proxy.ProxyRequest;
+import io.gravitee.gateway.api.stream.BufferedReadWriteStream;
 import io.gravitee.gateway.api.stream.ReadWriteStream;
 import io.gravitee.gateway.api.stream.SimpleReadWriteStream;
 import io.gravitee.policy.api.annotations.OnRequestContent;
 import io.gravitee.policy.trafficshadowing.configuration.TrafficShadowingPolicyConfiguration;
+import java.util.ArrayList;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +50,8 @@ public class TrafficShadowingPolicy {
     public ReadWriteStream<Buffer> onRequestContent(ExecutionContext context) {
         final EndpointResolver endpointResolver = context.getComponent(EndpointResolver.class);
 
-        final String target = context.getTemplateEngine().getValue(configuration.getTarget(), String.class);
+        String configurationTarget = configuration.getTarget();
+        String target = context.getTemplateEngine().eval(configurationTarget, String.class).blockingGet();
         ProxyEndpoint endpoint = endpointResolver.resolve(target);
 
         if (endpoint != null) {
@@ -57,65 +61,97 @@ public class TrafficShadowingPolicy {
                 proxyRequestBuilder -> proxyRequestBuilder.headers(shadowingHeaders)
             );
 
-            ProxyConnection connection = endpoint.connector().request(proxyRequest);
-
-            if (connection != null) {
-                connection.responseHandler(
-                    response -> {
-                        LOGGER.debug("Traffic shadowing status is: {}", response.status());
-
-                        response.bodyHandler(buffer -> {}).endHandler(handler -> {});
-                    }
-                );
-
-                return new SimpleReadWriteStream<Buffer>() {
-                    @Override
-                    public SimpleReadWriteStream<Buffer> write(Buffer chunk) {
-                        connection.write(chunk);
-
-                        if (connection.writeQueueFull()) {
-                            pause();
-                            connection.drainHandler(aVoid -> resume());
-                        }
-
-                        return super.write(chunk);
-                    }
-
-                    @Override
-                    public void end() {
-                        connection.end();
-                        super.end();
-                    }
-                };
-            }
+            return new ShadowingReadWriteStream(proxyRequest, context, endpoint);
         }
 
         return null;
     }
 
     private HttpHeaders addShadowingHeaders(HttpHeaders headers, ExecutionContext context) {
-        HttpHeaders httpHeaders = new HttpHeaders(headers);
+        HttpHeaders httpHeaders = HttpHeaders.create(headers);
         if (configuration.getHeaders() != null) {
             configuration
                 .getHeaders()
-                .forEach(
-                    header -> {
-                        if (header.getName() != null && !header.getName().trim().isEmpty()) {
-                            try {
-                                String extValue = (header.getValue() != null)
-                                    ? context.getTemplateEngine().convert(header.getValue())
-                                    : null;
-                                if (extValue != null) {
-                                    httpHeaders.set(header.getName(), extValue);
-                                }
-                            } catch (Exception ex) {
-                                // Do nothing
-                                ex.printStackTrace();
+                .forEach(header -> {
+                    if (header.getName() != null && !header.getName().trim().isEmpty()) {
+                        try {
+                            String extValue = (header.getValue() != null)
+                                ? context.getTemplateEngine().eval(header.getValue(), String.class).blockingGet()
+                                : null;
+                            if (extValue != null) {
+                                httpHeaders.set(header.getName(), extValue);
                             }
+                        } catch (Exception ex) {
+                            // Do nothing
+                            ex.printStackTrace();
                         }
+                    }
+                });
+        }
+        return httpHeaders;
+    }
+
+    private static class ShadowingReadWriteStream extends BufferedReadWriteStream {
+
+        ProxyConnection connection;
+
+        List<Buffer> chunkBuffers = new ArrayList<>();
+
+        public ShadowingReadWriteStream(ProxyRequest proxyRequest, ExecutionContext context, ProxyEndpoint endpoint) {
+            endpoint
+                .connector()
+                .request(
+                    proxyRequest,
+                    context,
+                    connection -> {
+                        this.connection = connection;
+
+                        connection.responseHandler(response -> {
+                            LOGGER.debug("Traffic shadowing status is: {}", response.status());
+                        });
+                        connection.exceptionHandler(throwable -> {
+                            LOGGER.error("An error occurs while sending traffic shadowing request", throwable);
+                        });
                     }
                 );
         }
-        return httpHeaders;
+
+        @Override
+        public SimpleReadWriteStream<Buffer> write(Buffer chunk) {
+            if (connection == null) {
+                chunkBuffers.add(chunk);
+            } else {
+                sendPendingChunkBuffers();
+                writeChunk(chunk);
+            }
+
+            return super.write(chunk);
+        }
+
+        private void sendPendingChunkBuffers() {
+            if (!chunkBuffers.isEmpty()) {
+                chunkBuffers.forEach(this::writeChunk);
+                chunkBuffers.clear();
+            }
+        }
+
+        private void writeChunk(Buffer buffer) {
+            connection.write(buffer);
+            if (connection.writeQueueFull()) {
+                pause();
+                connection.drainHandler(aVoid -> resume());
+            }
+        }
+
+        @Override
+        public void end() {
+            if (connection == null) {
+                LOGGER.warn("No connection available to send traffic shadowing request");
+            } else {
+                sendPendingChunkBuffers();
+                connection.end();
+            }
+            super.end();
+        }
     }
 }

--- a/src/test/java/io/gravitee/policy/trafficshadowing/TrafficShadowingPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/trafficshadowing/TrafficShadowingPolicyIntegrationTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.trafficshadowing;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.policy.trafficshadowing.configuration.TrafficShadowingPolicyConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@GatewayTest
+class TrafficShadowingPolicyIntegrationTest extends AbstractPolicyTest<TrafficShadowingPolicy, TrafficShadowingPolicyConfiguration> {
+
+    @Test
+    @DisplayName("Should shadow request to another endpoint")
+    @DeployApi("/apis/traffic-shadowing.json")
+    void shouldTransformAndAddHeadersOnRequestContent(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(post("/endpoint").willReturn(ok()));
+        wiremock.stubFor(post("/shadow-endpoint").willReturn(ok()));
+
+        httpClient
+            .rxRequest(HttpMethod.POST, "/test")
+            .flatMap(httpClientRequest -> httpClientRequest.rxSend("A request"))
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(postRequestedFor(urlPathEqualTo("/endpoint")));
+        wiremock.verify(postRequestedFor(urlPathEqualTo("/shadow-endpoint")).withHeader("Custom-Request-Id-Header", containing("id-")));
+    }
+}

--- a/src/test/java/io/gravitee/policy/trafficshadowing/TrafficShadowingPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/trafficshadowing/TrafficShadowingPolicyTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.api.Connector;
 import io.gravitee.gateway.api.ExecutionContext;
@@ -33,6 +32,7 @@ import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.endpoint.EndpointAvailabilityListener;
 import io.gravitee.gateway.api.endpoint.resolver.EndpointResolver;
 import io.gravitee.gateway.api.endpoint.resolver.ProxyEndpoint;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.proxy.ProxyRequest;
 import io.gravitee.gateway.api.proxy.builder.ProxyRequestBuilder;
 import io.gravitee.policy.trafficshadowing.configuration.HttpHeader;
@@ -78,13 +78,13 @@ public class TrafficShadowingPolicyTest {
     @Mock
     private Connector connector;
 
-    private HttpHeaders requestHttpHeaders = new HttpHeaders();
+    private io.gravitee.gateway.api.http.HttpHeaders requestHttpHeaders = HttpHeaders.create();
 
     @Before
     public void init() {
         initMocks(this);
 
-        requestHttpHeaders = new HttpHeaders();
+        requestHttpHeaders = HttpHeaders.create();
         trafficShadowingPolicy = new TrafficShadowingPolicy(trafficShadowingPolicyConfiguration);
         when(executionContext.getTemplateEngine()).thenReturn(templateEngine);
         when(executionContext.getComponent(EndpointResolver.class)).thenReturn(endpointResolver);
@@ -124,7 +124,7 @@ public class TrafficShadowingPolicyTest {
 
         trafficShadowingPolicy.onRequestContent(executionContext);
 
-        verify(connector).request(proxyRequestArgumentCaptor.capture());
+        verify(connector).request(proxyRequestArgumentCaptor.capture(), any(), any());
 
         assertEquals(2, proxyRequestArgumentCaptor.getValue().headers().size());
         assertTrue(proxyRequestArgumentCaptor.getValue().headers().containsKey("X-Gravitee-Policy"));
@@ -142,11 +142,11 @@ public class TrafficShadowingPolicyTest {
 
         trafficShadowingPolicy.onRequestContent(executionContext);
 
-        verify(connector).request(proxyRequestArgumentCaptor.capture());
+        verify(connector).request(proxyRequestArgumentCaptor.capture(), any(), any());
 
         assertEquals(1, proxyRequestArgumentCaptor.getValue().headers().size());
         assertTrue(proxyRequestArgumentCaptor.getValue().headers().containsKey("X-Gravitee-Policy"));
-        assertEquals("custom", proxyRequestArgumentCaptor.getValue().headers().get("X-Gravitee-Policy").get(0));
+        assertEquals("custom", proxyRequestArgumentCaptor.getValue().headers().get("X-Gravitee-Policy"));
     }
 
     public static class MockProxyEndpoint implements ProxyEndpoint {

--- a/src/test/resources/apis/traffic-shadowing.json
+++ b/src/test/resources/apis/traffic-shadowing.json
@@ -1,0 +1,58 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      },
+      {
+        "name": "shadow-endpoint",
+        "target": "http://localhost:8080/shadow-endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "POST"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Traffic Shadowing",
+          "description": "",
+          "enabled": true,
+          "policy": "traffic-shadowing",
+          "configuration": {
+            "scope": "REQUEST_CONTENT",
+            "target": "{#endpoints['shadow-endpoint']}",
+            "headers": [
+              {
+                "name": "Custom-Request-Id-Header",
+                "value": "id-{#request.id}"
+              }
+            ]
+          }
+        }
+      ],
+      "post": []
+    }
+  ]
+}


### PR DESCRIPTION
**Issue**

gravitee-io/issues#8385

**Description**

bump gravitee-parent, gravitee-common, gravitee-gateway-api and adapt code.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-adapt-3-15-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-traffic-shadowing/2.0.0-adapt-3-15-x-SNAPSHOT/gravitee-policy-traffic-shadowing-2.0.0-adapt-3-15-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
