### PR TITLE
fix: some handlers are mandatory before calling invoker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.5.0
+    gravitee: gravitee-io/gravitee@4.1.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,27 +1,25 @@
 {
-  "extends": [
-    "config:base"
-  ],
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "ci"
-    },
-    {
-      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "chore"
-    },
-    {
-      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-      "matchUpdateTypes": ["major"],
-      "semanticCommitType": "chore"
-    }
-  ]
+    "extends": ["config:base"],
+    "rebaseWhen": "conflicted",
+    "packageRules": [
+        {
+            "matchDatasources": ["orb"],
+            "matchUpdateTypes": ["patch", "minor"],
+            "automerge": true,
+            "automergeType": "branch",
+            "semanticCommitType": "ci"
+        },
+        {
+            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+            "matchUpdateTypes": ["patch", "minor"],
+            "automerge": true,
+            "automergeType": "branch",
+            "semanticCommitType": "chore"
+        },
+        {
+            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+            "matchUpdateTypes": ["major"],
+            "semanticCommitType": "chore"
+        }
+    ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,15 +31,11 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.1</version>
+        <version>22.2.4</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>3.0.27</gravitee-bom.version>
-        <gravitee-gateway-api.version>2.0.1</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>2.3.0</gravitee-common.version>
-        <gravitee-gateway.version>3.20.3-SNAPSHOT</gravitee-gateway.version>
+        <gravitee-apim-bom.version>4.6.0-SNAPSHOT</gravitee-apim-bom.version>
 
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <prettier-maven-plugin.version>0.22</prettier-maven-plugin.version>
@@ -53,9 +49,9 @@
             <!-- Gravitee dependencies -->
             <!-- Import bom to properly inherit all dependencies -->
             <dependency>
-                <groupId>io.gravitee</groupId>
-                <artifactId>gravitee-bom</artifactId>
-                <version>${gravitee-bom.version}</version>
+                <groupId>io.gravitee.apim</groupId>
+                <artifactId>gravitee-apim-bom</artifactId>
+                <version>${gravitee-apim-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -67,21 +63,18 @@
         <dependency>
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>
-            <version>${gravitee-gateway-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-api</artifactId>
-            <version>${gravitee-policy-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.common</groupId>
             <artifactId>gravitee-common</artifactId>
-            <version>${gravitee-common.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -120,7 +113,7 @@
         <dependency>
             <groupId>io.gravitee.apim.gateway</groupId>
             <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
-            <version>${gravitee-gateway.version}</version>
+            <version>${gravitee-apim-bom.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/assembly/policy-assembly.xml
+++ b/src/assembly/policy-assembly.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/trafficshadowing/TrafficShadowingPolicy.java
+++ b/src/main/java/io/gravitee/policy/trafficshadowing/TrafficShadowingPolicy.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/trafficshadowing/configuration/HttpHeader.java
+++ b/src/main/java/io/gravitee/policy/trafficshadowing/configuration/HttpHeader.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/trafficshadowing/configuration/TrafficShadowingPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/trafficshadowing/configuration/TrafficShadowingPolicyConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/trafficshadowing/invoker/ShadowProxyConnection.java
+++ b/src/main/java/io/gravitee/policy/trafficshadowing/invoker/ShadowProxyConnection.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,33 +21,15 @@ import io.gravitee.gateway.api.http2.HttpFrame;
 import io.gravitee.gateway.api.proxy.ProxyConnection;
 import io.gravitee.gateway.api.proxy.ProxyResponse;
 import io.gravitee.gateway.api.stream.WriteStream;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@RequiredArgsConstructor
 public class ShadowProxyConnection implements ProxyConnection {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(ShadowProxyConnection.class);
 
     private final ProxyConnection incomingProxyConnection;
     private final ProxyConnection shadowConnection;
-
-    public ShadowProxyConnection(ProxyConnection incomingProxyConnection, ProxyConnection shadowConnection) {
-        this.incomingProxyConnection = incomingProxyConnection;
-        this.shadowConnection = shadowConnection;
-
-        shadowConnection.responseHandler(response -> {
-            LOGGER.debug("Traffic shadowing status is: {}", response.status());
-
-            response.bodyHandler(noop -> {}).endHandler(noop -> {});
-
-            // Resume the shadow response to read the stream and mark as ended
-            response.resume();
-        });
-
-        shadowConnection.exceptionHandler(throwable -> {
-            LOGGER.error("An error occurs while sending traffic shadowing request", throwable);
-        });
-    }
 
     @Override
     public ProxyConnection writeCustomFrame(HttpFrame frame) {

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,46 +1,41 @@
 {
-  "type": "object",
-  "id": "urn:jsonschema:io:gravitee:policy:trafficshadowing:configuration:TrafficShadowingPolicy",
-  "properties": {
-    "target" : {
-      "title": "Target",
-      "description": "Target",
-      "type" : "string",
-      "x-schema-form": {
-        "expression-language": true
-      }
-    },
-    "headers" : {
-      "type" : "array",
-      "title": "Add / update headers",
-      "items" : {
-        "type" : "object",
-        "id" : "urn:jsonschema:io:gravitee:policy:trafficshadowing:configuration:HttpHeader",
-        "title": "Header",
-        "properties" : {
-          "name" : {
-            "title": "Name",
-            "description": "Name of the header",
-            "type" : "string",
-            "pattern" : "^\\S*$",
-            "validationMessage": {
-              "202": "Header name must not contain spaces."
+    "type": "object",
+    "id": "urn:jsonschema:io:gravitee:policy:trafficshadowing:configuration:TrafficShadowingPolicy",
+    "properties": {
+        "target": {
+            "title": "Target",
+            "description": "Target",
+            "type": "string",
+            "x-schema-form": {
+                "expression-language": true
             }
-          },
-          "value" : {
-            "title": "Value",
-            "description": "Value of the header",
-            "type" : "string"
-          }
         },
-        "required": [
-          "name",
-          "value"
-        ]
-      }
-    }
-  },
-  "required": [
-    "target"
-  ]
+        "headers": {
+            "type": "array",
+            "title": "Add / update headers",
+            "items": {
+                "type": "object",
+                "id": "urn:jsonschema:io:gravitee:policy:trafficshadowing:configuration:HttpHeader",
+                "title": "Header",
+                "properties": {
+                    "name": {
+                        "title": "Name",
+                        "description": "Name of the header",
+                        "type": "string",
+                        "pattern": "^\\S*$",
+                        "validationMessage": {
+                            "202": "Header name must not contain spaces."
+                        }
+                    },
+                    "value": {
+                        "title": "Value",
+                        "description": "Value of the header",
+                        "type": "string"
+                    }
+                },
+                "required": ["name", "value"]
+            }
+        }
+    },
+    "required": ["target"]
 }

--- a/src/test/java/io/gravitee/policy/trafficshadowing/TrafficShadowingPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/trafficshadowing/TrafficShadowingPolicyIntegrationTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,12 @@
  */
 package io.gravitee.policy.trafficshadowing;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
@@ -24,17 +29,17 @@ import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.policy.trafficshadowing.configuration.TrafficShadowingPolicyConfiguration;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.rxjava3.core.http.HttpClient;
-import io.vertx.rxjava3.core.http.HttpClientRequest;
-import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
 @GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class TrafficShadowingPolicyIntegrationTest extends AbstractPolicyTest<TrafficShadowingPolicy, TrafficShadowingPolicyConfiguration> {
 
     @Test
-    @DisplayName("Should shadow request to another endpoint")
     @DeployApi("/apis/traffic-shadowing.json")
-    void shouldTransformAndAddHeadersOnRequestContent(HttpClient httpClient) throws InterruptedException {
+    void should_transform_and_add_headers_on_request_content(HttpClient httpClient) throws InterruptedException {
         wiremock.stubFor(post("/endpoint").willReturn(ok()));
         wiremock.stubFor(post("/shadow-endpoint").willReturn(ok()));
 
@@ -59,9 +64,8 @@ class TrafficShadowingPolicyIntegrationTest extends AbstractPolicyTest<TrafficSh
     }
 
     @Test
-    @DisplayName("Should not shadow request to an invalid endpoint")
     @DeployApi("/apis/traffic-shadowing-bad-endpoint.json")
-    void shouldCallDefaultEndpoint(HttpClient httpClient) throws InterruptedException {
+    void should_ignore_invalid_shadowing_endpoint_and_call_standard_endpoint(HttpClient httpClient) throws InterruptedException {
         wiremock.stubFor(post("/endpoint").willReturn(ok()));
         wiremock.stubFor(post("/shadow-endpoint").willReturn(ok()));
 
@@ -78,5 +82,6 @@ class TrafficShadowingPolicyIntegrationTest extends AbstractPolicyTest<TrafficSh
             .assertNoErrors();
 
         wiremock.verify(postRequestedFor(urlPathEqualTo("/endpoint")).withRequestBody(equalTo("A request")));
+        wiremock.verify(0, postRequestedFor(urlPathEqualTo("/shadow-endpoint")).withRequestBody(equalTo("A request")));
     }
 }

--- a/src/test/java/io/gravitee/policy/trafficshadowing/configuration/TrafficShadowingPolicyConfigurationTest.java
+++ b/src/test/java/io/gravitee/policy/trafficshadowing/configuration/TrafficShadowingPolicyConfigurationTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/trafficshadowing/invoker/MockProxyEndpoint.java
+++ b/src/test/java/io/gravitee/policy/trafficshadowing/invoker/MockProxyEndpoint.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/trafficshadowing/invoker/ShadowInvokerTest.java
+++ b/src/test/java/io/gravitee/policy/trafficshadowing/invoker/ShadowInvokerTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/trafficshadowing/invoker/ShadowProxyConnectionTest.java
+++ b/src/test/java/io/gravitee/policy/trafficshadowing/invoker/ShadowProxyConnectionTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/apis/traffic-shadowing-bad-endpoint.json
+++ b/src/test/resources/apis/traffic-shadowing-bad-endpoint.json
@@ -1,58 +1,56 @@
 {
-  "id": "my-api",
-  "name": "my-api",
-  "gravitee": "2.0.0",
-  "proxy": {
-    "context_path": "/test",
-    "endpoints": [
-      {
-        "name": "default",
-        "target": "http://localhost:8080/endpoint",
-        "http": {
-          "connectTimeout": 3000,
-          "readTimeout": 60000
-        }
-      },
-      {
-        "name": "shadow-endpoint",
-        "target": "http://localhost:65535/shadow-endpoint",
-        "http": {
-          "connectTimeout": 3000,
-          "readTimeout": 60000
-        }
-      }
-    ]
-  },
-  "flows": [
-    {
-      "name": "flow-1",
-      "methods": [
-        "POST"
-      ],
-      "enabled": true,
-      "path-operator": {
-        "path": "/",
-        "operator": "STARTS_WITH"
-      },
-      "pre": [
+    "id": "my-api",
+    "name": "my-api",
+    "gravitee": "2.0.0",
+    "proxy": {
+        "context_path": "/test",
+        "endpoints": [
+            {
+                "name": "default",
+                "target": "http://localhost:8080/endpoint",
+                "http": {
+                    "connectTimeout": 3000,
+                    "readTimeout": 60000
+                }
+            },
+            {
+                "name": "shadow-endpoint",
+                "target": "http://localhost:12345/shadow-endpoint",
+                "http": {
+                    "connectTimeout": 3000,
+                    "readTimeout": 60000
+                }
+            }
+        ]
+    },
+    "flows": [
         {
-          "name": "Traffic Shadowing",
-          "description": "",
-          "enabled": true,
-          "policy": "traffic-shadowing",
-          "configuration": {
-            "scope": "REQUEST_CONTENT",
-            "target": "{#endpoints['shadow-endpoint']}",
-            "headers": [
-              {
-                "name": "Custom-Request-Id-Header",
-                "value": "id-{#request.id}"
-              }
-            ]
-          }
+            "name": "flow-1",
+            "methods": ["POST"],
+            "enabled": true,
+            "path-operator": {
+                "path": "/",
+                "operator": "STARTS_WITH"
+            },
+            "pre": [
+                {
+                    "name": "Traffic Shadowing",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "traffic-shadowing",
+                    "configuration": {
+                        "scope": "REQUEST_CONTENT",
+                        "target": "{#endpoints['shadow-endpoint']}",
+                        "headers": [
+                            {
+                                "name": "Custom-Request-Id-Header",
+                                "value": "id-{#request.id}"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "post": []
         }
-      ],
-      "post": []
-    }
-  ]
+    ]
 }

--- a/src/test/resources/apis/traffic-shadowing.json
+++ b/src/test/resources/apis/traffic-shadowing.json
@@ -1,58 +1,56 @@
 {
-  "id": "my-api",
-  "name": "my-api",
-  "gravitee": "2.0.0",
-  "proxy": {
-    "context_path": "/test",
-    "endpoints": [
-      {
-        "name": "default",
-        "target": "http://localhost:8080/endpoint",
-        "http": {
-          "connectTimeout": 3000,
-          "readTimeout": 60000
-        }
-      },
-      {
-        "name": "shadow-endpoint",
-        "target": "http://localhost:8080/shadow-endpoint",
-        "http": {
-          "connectTimeout": 3000,
-          "readTimeout": 60000
-        }
-      }
-    ]
-  },
-  "flows": [
-    {
-      "name": "flow-1",
-      "methods": [
-        "POST"
-      ],
-      "enabled": true,
-      "path-operator": {
-        "path": "/",
-        "operator": "STARTS_WITH"
-      },
-      "pre": [
+    "id": "my-api",
+    "name": "my-api",
+    "gravitee": "2.0.0",
+    "proxy": {
+        "context_path": "/test",
+        "endpoints": [
+            {
+                "name": "default",
+                "target": "http://localhost:8080/endpoint",
+                "http": {
+                    "connectTimeout": 3000,
+                    "readTimeout": 60000
+                }
+            },
+            {
+                "name": "shadow-endpoint",
+                "target": "http://localhost:8080/shadow-endpoint",
+                "http": {
+                    "connectTimeout": 3000,
+                    "readTimeout": 60000
+                }
+            }
+        ]
+    },
+    "flows": [
         {
-          "name": "Traffic Shadowing",
-          "description": "",
-          "enabled": true,
-          "policy": "traffic-shadowing",
-          "configuration": {
-            "scope": "REQUEST_CONTENT",
-            "target": "{#endpoints['shadow-endpoint']}",
-            "headers": [
-              {
-                "name": "Custom-Request-Id-Header",
-                "value": "id-{#request.id}"
-              }
-            ]
-          }
+            "name": "flow-1",
+            "methods": ["POST"],
+            "enabled": true,
+            "path-operator": {
+                "path": "/",
+                "operator": "STARTS_WITH"
+            },
+            "pre": [
+                {
+                    "name": "Traffic Shadowing",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "traffic-shadowing",
+                    "configuration": {
+                        "scope": "REQUEST_CONTENT",
+                        "target": "{#endpoints['shadow-endpoint']}",
+                        "headers": [
+                            {
+                                "name": "Custom-Request-Id-Header",
+                                "value": "id-{#request.id}"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "post": []
         }
-      ],
-      "post": []
-    }
-  ]
+    ]
 }

--- a/src/test/resources/io/gravitee/policy/trafficshadowing/configuration/configuration.json
+++ b/src/test/resources/io/gravitee/policy/trafficshadowing/configuration/configuration.json
@@ -1,13 +1,13 @@
 {
-  "target": "target_endpoint",
-  "headers": [
-    {
-      "name": "X-Gravitee-Header-Test",
-      "value": "Value"
-    },
-    {
-      "name": "X-Gravitee-Second-Header-Test",
-      "value": "Value"
-    }
-  ]
+    "target": "target_endpoint",
+    "headers": [
+        {
+            "name": "X-Gravitee-Header-Test",
+            "value": "Value"
+        },
+        {
+            "name": "X-Gravitee-Second-Header-Test",
+            "value": "Value"
+        }
+    ]
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-445

**Description**

Initialize shadow handlers before calling the invoker to avoid some weird behavior (npe)

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.2-archi-445-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-traffic-shadowing/2.0.2-archi-445-SNAPSHOT/gravitee-policy-traffic-shadowing-2.0.2-archi-445-SNAPSHOT.zip)
  <!-- Version placeholder end -->
