### PR TITLE
fix: prevent dynamic routing attributes from leaking into shadow context

### DIFF
--- a/src/main/java/io/gravitee/policy/trafficshadowing/invoker/ShadowHttpExecutionContext.java
+++ b/src/main/java/io/gravitee/policy/trafficshadowing/invoker/ShadowHttpExecutionContext.java
@@ -18,6 +18,7 @@ package io.gravitee.policy.trafficshadowing.invoker;
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.context.ContextAttributes;
 import io.gravitee.gateway.reactive.api.context.TlsSession;
 import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpRequest;
@@ -32,8 +33,19 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class ShadowHttpExecutionContext implements HttpExecutionContext {
+
+    /**
+     * Routing attributes set by policies such as Dynamic Routing. These must not leak into the
+     * shadow context, otherwise the shadow endpoint connector would follow the dynamic route
+     * instead of using its own configured endpoint.
+     */
+    private static final Set<String> ROUTING_ATTRIBUTES = Set.of(
+        ContextAttributes.ATTR_REQUEST_ENDPOINT,
+        ContextAttributes.ATTR_REQUEST_ENDPOINT_OVERRIDE
+    );
 
     private final HttpExecutionContext incomingContext;
     private final ShadowResponse response;
@@ -121,22 +133,34 @@ public class ShadowHttpExecutionContext implements HttpExecutionContext {
 
     @Override
     public <T> T getAttribute(String s) {
+        if (ROUTING_ATTRIBUTES.contains(s)) {
+            return null;
+        }
         return incomingContext.getAttribute(s);
     }
 
     @Override
     public <T> List<T> getAttributeAsList(String s) {
+        if (ROUTING_ATTRIBUTES.contains(s)) {
+            return List.of();
+        }
         return incomingContext.getAttributeAsList(s);
     }
 
     @Override
     public Set<String> getAttributeNames() {
-        return incomingContext.getAttributeNames();
+        return incomingContext
+            .getAttributeNames()
+            .stream()
+            .filter(name -> !ROUTING_ATTRIBUTES.contains(name))
+            .collect(Collectors.toUnmodifiableSet());
     }
 
     @Override
     public <T> Map<String, T> getAttributes() {
-        return Collections.unmodifiableMap(incomingContext.getAttributes());
+        Map<String, T> attributes = new java.util.HashMap<>(incomingContext.getAttributes());
+        attributes.keySet().removeAll(ROUTING_ATTRIBUTES);
+        return Collections.unmodifiableMap(attributes);
     }
 
     @Override


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13810

**Description**

A customer set up a v4 API with two policies on the same flow:

Traffic Shadowing — silently copies every request to a second "shadow" backend (useful for testing a new backend without affecting real users)
Dynamic Routing — rewrites the request path based on rules (e.g. /hello → /dynamic/hello)

The bug: When both policies are active together, the shadow backend receives nothing. Zero traffic. Disabling Dynamic Routing makes shadowing work again.

**Additional context**

What The Change Does — Line by Line
```
private static final Set<String> ROUTING_ATTRIBUTES = Set.of(
    ContextAttributes.ATTR_REQUEST_ENDPOINT,
    ContextAttributes.ATTR_REQUEST_ENDPOINT_OVERRIDE
);
```
Defines a list of the two "routing note" attribute names that Dynamic Routing writes. These are the ones we want the shadow to ignore.

**Before the fix**, the shadow context was like a transparent window into the main context — everything the main request had, the shadow saw too, including Dynamic Routing's instructions.
**After the fix**, the shadow context is like a window with a filter — it shows everything from the main context except routing instructions. The shadow connector sees no routing note, so it routes using its own endpoint configuration and the original request path (/hello), exactly as intended.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.1-APIM-13810-traffic-shadowing-policy-does-not-function-correctly-when-used-with-dynamic-routing-policy-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-traffic-shadowing/3.0.1-APIM-13810-traffic-shadowing-policy-does-not-function-correctly-when-used-with-dynamic-routing-policy-SNAPSHOT/gravitee-policy-traffic-shadowing-3.0.1-APIM-13810-traffic-shadowing-policy-does-not-function-correctly-when-used-with-dynamic-routing-policy-SNAPSHOT.zip)
  <!-- Version placeholder end -->
