### PR TITLE
fix: traffic shadowing does not work with failover for v2 apis

### DIFF
--- a/src/main/java/io/gravitee/policy/trafficshadowing/v3/invoker/ShadowInvoker.java
+++ b/src/main/java/io/gravitee/policy/trafficshadowing/v3/invoker/ShadowInvoker.java
@@ -29,6 +29,8 @@ import io.gravitee.gateway.api.proxy.ProxyRequest;
 import io.gravitee.gateway.api.stream.ReadStream;
 import io.gravitee.policy.trafficshadowing.configuration.HttpHeader;
 import io.gravitee.policy.trafficshadowing.configuration.TrafficShadowingPolicyConfiguration;
+import java.util.ArrayList;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,6 +77,43 @@ public class ShadowInvoker implements Invoker {
             proxyRequestBuilder -> proxyRequestBuilder.headers(shadowHeaders)
         );
 
+        // Buffer body chunks so we can replay them to the shadow connection when the inner
+        // invoker (e.g. FailoverInvoker) consumes the stream before our callback fires.
+        final List<Buffer> bodyBuffer = new ArrayList<>();
+        final boolean[] streamEnded = { false };
+
+        final ReadStream<Buffer> recordingStream = new ReadStream<>() {
+            @Override
+            public ReadStream<Buffer> bodyHandler(Handler<Buffer> bodyHandler) {
+                stream.bodyHandler(chunk -> {
+                    bodyBuffer.add(Buffer.buffer(chunk.getBytes()));
+                    if (bodyHandler != null) bodyHandler.handle(chunk);
+                });
+                return this;
+            }
+
+            @Override
+            public ReadStream<Buffer> endHandler(Handler<Void> endHandler) {
+                stream.endHandler(v -> {
+                    streamEnded[0] = true;
+                    if (endHandler != null) endHandler.handle(v);
+                });
+                return this;
+            }
+
+            @Override
+            public ReadStream<Buffer> pause() {
+                stream.pause();
+                return this;
+            }
+
+            @Override
+            public ReadStream<Buffer> resume() {
+                stream.resume();
+                return this;
+            }
+        };
+
         endpoint
             .connector()
             .request(
@@ -96,16 +135,24 @@ public class ShadowInvoker implements Invoker {
 
                     invoker.invoke(
                         context,
-                        stream,
+                        recordingStream,
                         backendConnection -> {
                             final ShadowProxyConnection shadowProxyConnection = new ShadowProxyConnection(
                                 backendConnection,
                                 shadowConnection
                             );
 
-                            // Plug underlying stream to connection stream
-                            stream.bodyHandler(shadowProxyConnection::write);
-                            stream.endHandler(aVoid -> shadowProxyConnection.end());
+                            if (streamEnded[0]) {
+                                // The inner invoker (e.g. FailoverInvoker) consumed the stream before
+                                // this callback fired. Replay the buffered body to the shadow endpoint.
+                                bodyBuffer.forEach(shadowConnection::write);
+                                shadowConnection.end();
+                            } else {
+                                // Normal path: stream not yet flowing. Plug it so both endpoints
+                                // receive writes via ShadowProxyConnection.
+                                stream.bodyHandler(shadowProxyConnection::write);
+                                stream.endHandler(aVoid -> shadowProxyConnection.end());
+                            }
 
                             connectionHandler.handle(shadowProxyConnection);
                         }

--- a/src/test/java/io/gravitee/policy/trafficshadowing/v3/invoker/ShadowInvokerTest.java
+++ b/src/test/java/io/gravitee/policy/trafficshadowing/v3/invoker/ShadowInvokerTest.java
@@ -32,6 +32,7 @@ import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.proxy.ProxyConnection;
 import io.gravitee.gateway.api.proxy.ProxyRequest;
+import io.gravitee.gateway.api.proxy.ProxyResponse;
 import io.gravitee.gateway.api.stream.ReadStream;
 import io.gravitee.policy.trafficshadowing.configuration.HttpHeader;
 import io.gravitee.policy.trafficshadowing.configuration.TrafficShadowingPolicyConfiguration;
@@ -152,5 +153,127 @@ public class ShadowInvokerTest {
         HttpHeaders shadowHeaders = proxyRequestArgumentCaptor.getValue().headers();
 
         assertThat(shadowHeaders).usingRecursiveComparison().isEqualTo(HttpHeaders.create(this.headers).set("X-Gravitee-Policy", "custom"));
+    }
+
+    /**
+     * Regression test for APIM-14211: when the inner invoker is FailoverInvoker, it consumes
+     * the request body stream before calling the backendConnection callback (the callback fires
+     * only after the circuit breaker onComplete, i.e. after a full round-trip). ShadowInvoker
+     * must buffer the body and replay it to the shadow connection in this case.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldReplayBufferedBodyToShadowWhenStreamConsumedByInnerInvokerBeforeCallback() {
+        when(endpointResolver.resolve(any())).thenReturn(shadowEndpoint);
+
+        ProxyConnection shadowConnection = mock(ProxyConnection.class);
+        when(shadowConnection.responseHandler(any())).thenReturn(shadowConnection);
+        when(shadowConnection.exceptionHandler(any())).thenReturn(shadowConnection);
+
+        // Shadow connector fires its callback immediately (connection established)
+        doAnswer(invocation -> {
+                Handler<ProxyConnection> shadowConnHandler = invocation.getArgument(2);
+                shadowConnHandler.handle(shadowConnection);
+                return null;
+            })
+            .when(connector)
+            .request(any(), any(), any());
+
+        // Capture the intercepting handlers that recordingStream registers on the underlying stream
+        ArgumentCaptor<Handler<Buffer>> streamBodyHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        ArgumentCaptor<Handler<Void>> streamEndHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        when(stream.bodyHandler(streamBodyHandlerCaptor.capture())).thenReturn(stream);
+        when(stream.endHandler(streamEndHandlerCaptor.capture())).thenReturn(stream);
+
+        ProxyConnection mainBackendConnection = mock(ProxyConnection.class);
+
+        // Simulate FailoverInvoker: consume the stream entirely, then call backendConnection callback
+        doAnswer(invocation -> {
+                ReadStream<Buffer> recordingStream = invocation.getArgument(1);
+                Handler<ProxyConnection> backendConnHandler = invocation.getArgument(2);
+
+                // EndpointInvoker registers handlers on recordingStream (which delegates to stream)
+                recordingStream.bodyHandler(chunk -> {});
+                recordingStream.endHandler(v -> {});
+
+                // Stream body flows (intercepting handlers on stream are now registered)
+                streamBodyHandlerCaptor.getValue().handle(Buffer.buffer("hello"));
+                streamBodyHandlerCaptor.getValue().handle(Buffer.buffer(" world"));
+                streamEndHandlerCaptor.getValue().handle(null);
+
+                // FailoverInvoker calls connectionHandler only after stream is consumed
+                backendConnHandler.handle(mainBackendConnection);
+                return null;
+            })
+            .when(invoker)
+            .invoke(any(), any(), any());
+
+        shadowInvoker.invoke(executionContext, stream, connectionHandler);
+
+        // Shadow connection must have received the replayed body chunks
+        ArgumentCaptor<Buffer> writtenBuffers = ArgumentCaptor.forClass(Buffer.class);
+        verify(shadowConnection, times(2)).write(writtenBuffers.capture());
+        assertThat(writtenBuffers.getAllValues()).extracting(Buffer::toString).containsExactly("hello", " world");
+        verify(shadowConnection).end();
+
+        verify(connectionHandler).handle(any(ShadowProxyConnection.class));
+    }
+
+    /**
+     * Ensures the normal path (EndpointInvoker, no failover) still works after the fix:
+     * when the backendConnection callback fires before the stream is consumed, body handlers
+     * are wired through ShadowProxyConnection so both endpoints receive the data.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldWireBodyHandlersViaShadowProxyConnectionWhenStreamNotYetConsumed() {
+        when(endpointResolver.resolve(any())).thenReturn(shadowEndpoint);
+
+        ProxyConnection shadowConnection = mock(ProxyConnection.class);
+        when(shadowConnection.responseHandler(any())).thenReturn(shadowConnection);
+        when(shadowConnection.exceptionHandler(any())).thenReturn(shadowConnection);
+
+        doAnswer(invocation -> {
+                Handler<ProxyConnection> shadowConnHandler = invocation.getArgument(2);
+                shadowConnHandler.handle(shadowConnection);
+                return null;
+            })
+            .when(connector)
+            .request(any(), any(), any());
+
+        ProxyConnection mainBackendConnection = mock(ProxyConnection.class);
+
+        // Simulate EndpointInvoker: call backendConnection callback BEFORE stream flows
+        doAnswer(invocation -> {
+                ReadStream<Buffer> recordingStream = invocation.getArgument(1);
+                Handler<ProxyConnection> backendConnHandler = invocation.getArgument(2);
+
+                // EndpointInvoker registers handlers on recordingStream, then calls the callback
+                recordingStream.bodyHandler(chunk -> {});
+                recordingStream.endHandler(v -> {});
+
+                // Callback fires before resume() — stream has NOT been consumed yet
+                backendConnHandler.handle(mainBackendConnection);
+                return null;
+            })
+            .when(invoker)
+            .invoke(any(), any(), any());
+
+        // Capture the bodyHandler eventually registered on the original stream by the else branch
+        ArgumentCaptor<Handler<Buffer>> streamBodyHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        when(stream.bodyHandler(streamBodyHandlerCaptor.capture())).thenReturn(stream);
+        when(stream.endHandler(any())).thenReturn(stream);
+
+        shadowInvoker.invoke(executionContext, stream, connectionHandler);
+
+        // The else branch must have overridden stream.bodyHandler with shadowProxyConnection::write,
+        // so sending a chunk through it writes to BOTH connections.
+        streamBodyHandlerCaptor.getValue().handle(Buffer.buffer("test"));
+
+        verify(mainBackendConnection).write(any(Buffer.class));
+        verify(shadowConnection).write(any(Buffer.class));
+        verify(shadowConnection, never()).end(); // end not called yet (endHandler not triggered)
+
+        verify(connectionHandler).handle(any(ShadowProxyConnection.class));
     }
 }


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-14211

---

Simple HTTP server running on port 8090:
```python
python3 -c "
from http.server import HTTPServer, BaseHTTPRequestHandler
class H(BaseHTTPRequestHandler):
    def do_GET(self):
        print('MAIN received:', self.path)
        self.send_response(200)
        self.end_headers()
        self.wfile.write(b'main-response')
HTTPServer(('', 8090), H).serve_forever()
"
```

Before:
https://github.com/user-attachments/assets/a1fefd13-cc1b-4855-b1ae-2533cb5cf4ea

After:
https://github.com/user-attachments/assets/ebc6f375-2a68-4a9e-aa1d-e1fe1b0fbc8d

---

**The problem it solves**

The old code set up body handlers like this:

```
  invoker.invoke(context, stream, backendConnection -> {
      stream.bodyHandler(shadowProxyConnection::write);  // write to both endpoints
      stream.endHandler(aVoid -> shadowProxyConnection.end());
      connectionHandler.handle(shadowProxyConnection);
  });
```

This assumes the callback fires before the stream starts flowing. With EndpointInvoker that's true — it calls the callback during connection setup, then calls context.request().resume() afterwards. But FailoverInvoker only calls the callback inside circuitBreaker.execute().onComplete(), which fires after a full round-trip to the main backend. By that point, the stream has already been consumed and stream.bodyHandler(...) is a no-op. The shadow endpoint never gets the body.

---

**The buffer and the flag**

```
  final List<Buffer> bodyBuffer = new ArrayList<>();
  final boolean[] streamEnded = { false };
```

bodyBuffer accumulates every body chunk as it flows past. streamEnded is a one-element array (the Java trick for a mutable boolean in a lambda). Both are captured by the closures below.

---

**The recordingStream**

```java
  final ReadStream<Buffer> recordingStream = new ReadStream<>() {
      @Override
      public ReadStream<Buffer> bodyHandler(Handler<Buffer> bodyHandler) {
          stream.bodyHandler(chunk -> {
              bodyBuffer.add(Buffer.buffer(chunk.getBytes()));
              if (bodyHandler != null) bodyHandler.handle(chunk);
          });
          return this;
      }

      @Override
      public ReadStream<Buffer> endHandler(Handler<Void> endHandler) {
          stream.endHandler(v -> {
              streamEnded[0] = true;
              if (endHandler != null) endHandler.handle(v);
          });
          return this;
      }

      @Override public ReadStream<Buffer> pause()  { stream.pause();  return this; }
      @Override public ReadStream<Buffer> resume() { stream.resume(); return this; }
  };
```

This is a thin wrapper around stream. When EndpointInvoker (deep inside FailoverInvoker) calls recordingStream.bodyHandler(mainWrite), instead of registering mainWrite on stream directly, it registers an intercepting handler that:
  1. Copies the chunk into bodyBuffer
  2. Then forwards it to mainWrite as normal

Same for endHandler: the interceptor sets streamEnded[0] = true before forwarding. The pause/resume delegates are just pass-throughs so back-pressure still works.

recordingStream is what gets passed to invoker.invoke() in place of the original stream.

---

**The branching callback**

```java
  invoker.invoke(context, recordingStream, backendConnection -> {
      final ShadowProxyConnection shadowProxyConnection =
          new ShadowProxyConnection(backendConnection, shadowConnection);

      if (streamEnded[0]) {
          bodyBuffer.forEach(shadowConnection::write);
          shadowConnection.end();
      } else {
          stream.bodyHandler(shadowProxyConnection::write);
          stream.endHandler(aVoid -> shadowProxyConnection.end());
      }

      connectionHandler.handle(shadowProxyConnection);
  });
```

When this callback fires, streamEnded[0] tells us what actually happened:

streamEnded[0] == true — the failover path. The inner invoker consumed the stream before calling us (all chunks are already in bodyBuffer). We replay them directly to the shadow connection and call shadowConnection.end(). The shadow connection has been sitting open waiting for a request body; it gets it now.

streamEnded[0] == false — the normal path. The callback fired during connection setup, before context.request().resume(). The stream hasn't flowed yet. We install shadowProxyConnection::write on the original stream, which is the pre-existing logic: when chunks flow later they go to ShadowProxyConnection, which forwards each chunk to both the main backend and the shadow endpoint simultaneously.

The connectionHandler.handle(shadowProxyConnection) at the end is the same in both paths — it signals the gateway that a connection is ready and response handling can begin.