### PR TITLE
fix(invoker): strip client Host header from shadow request headers

### DIFF
--- a/src/main/java/io/gravitee/policy/trafficshadowing/invoker/ShadowInvoker.java
+++ b/src/main/java/io/gravitee/policy/trafficshadowing/invoker/ShadowInvoker.java
@@ -15,10 +15,9 @@
  */
 package io.gravitee.policy.trafficshadowing.invoker;
 
+import static io.gravitee.gateway.api.http.HttpHeaderNames.HOST;
 import static org.springframework.util.StringUtils.hasText;
 
-import com.google.api.Http;
-import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.connector.endpoint.HttpEndpointConnector;
@@ -31,7 +30,6 @@ import io.gravitee.policy.trafficshadowing.configuration.HttpHeader;
 import io.gravitee.policy.trafficshadowing.configuration.TrafficShadowingPolicyConfiguration;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.processors.UnicastProcessor;
-import io.vertx.core.Vertx;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -137,6 +135,12 @@ public class ShadowInvoker implements HttpInvoker {
 
     private HttpHeaders handleConfigHeader(HttpExecutionContext ctx) {
         var shadowHeaders = HttpHeaders.create(ctx.request().headers());
+        // The incoming client's Host must not be forwarded to the shadow endpoint — the connection
+        // target comes from the shadow endpoint's URL. Keeping it here would trigger APIM-13512's
+        // setHost() logic in HttpConnector, changing TLS SNI to the client's host and causing TLS
+        // handshake failures when the shadow endpoint uses HTTPS. Policy-configured Host headers
+        // (added below) are preserved and will correctly override the shadow endpoint's Host.
+        shadowHeaders.remove(HOST);
         if (configuration.getHeaders() != null) {
             configuration.getHeaders().forEach(configHeader -> addConfigHeader(ctx, shadowHeaders, configHeader));
         }

--- a/src/test/java/io/gravitee/policy/trafficshadowing/invoker/ShadowInvokerTest.java
+++ b/src/test/java/io/gravitee/policy/trafficshadowing/invoker/ShadowInvokerTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.trafficshadowing.invoker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
+import io.gravitee.el.TemplateEngine;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.reactive.api.connector.endpoint.HttpEndpointConnector;
+import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpRequest;
+import io.gravitee.gateway.reactive.api.invoker.HttpInvoker;
+import io.gravitee.gateway.reactive.core.v4.endpoint.EndpointManager;
+import io.gravitee.gateway.reactive.core.v4.endpoint.ManagedEndpoint;
+import io.gravitee.policy.trafficshadowing.configuration.HttpHeader;
+import io.gravitee.policy.trafficshadowing.configuration.TrafficShadowingPolicyConfiguration;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+class ShadowInvokerTest {
+
+    @Mock
+    private HttpInvoker defaultInvoker;
+
+    @Mock
+    private TrafficShadowingPolicyConfiguration configuration;
+
+    @Mock
+    private HttpExecutionContext ctx;
+
+    @Mock
+    private HttpRequest request;
+
+    @Mock
+    private TemplateEngine templateEngine;
+
+    @Mock
+    private EndpointManager endpointManager;
+
+    @Mock
+    private ManagedEndpoint endpoint;
+
+    @Mock
+    private HttpEndpointConnector connector;
+
+    @Mock
+    private Endpoint endpointDefinition;
+
+    private ShadowInvoker shadowInvoker;
+
+    @BeforeEach
+    void setUp() {
+        openMocks(this);
+        shadowInvoker = new ShadowInvoker(defaultInvoker, configuration);
+
+        when(ctx.request()).thenReturn(request);
+        when(ctx.getTemplateEngine()).thenReturn(templateEngine);
+        when(ctx.getComponent(EndpointManager.class)).thenReturn(endpointManager);
+        when(templateEngine.evalNow(anyString(), any())).thenAnswer(returnsFirstArg());
+        when(configuration.getTarget()).thenReturn("shadow-endpoint");
+        when(endpointManager.next(any())).thenReturn(endpoint);
+        when(endpoint.getDefinition()).thenReturn(endpointDefinition);
+        when(endpointDefinition.getName()).thenReturn("shadow");
+        when(endpoint.getConnector()).thenReturn(connector);
+        when(defaultInvoker.invoke(ctx)).thenReturn(Completable.complete());
+        when(request.chunks()).thenReturn(Flowable.<Buffer>empty());
+    }
+
+    /**
+     * Regression test for APIM-14291: the incoming client's Host header must not leak into the
+     * shadow request. If it did, HttpConnector's setHost() call (added by APIM-13512) would change
+     * the TLS SNI to the client's host, causing handshake failures against HTTPS shadow endpoints.
+     */
+    @Test
+    void should_strip_client_host_header_from_shadow_request() {
+        var incomingHeaders = HttpHeaders.create();
+        incomingHeaders.set("Host", "api.example.com");
+        incomingHeaders.set("X-Custom", "value");
+        when(request.headers()).thenReturn(incomingHeaders);
+
+        var shadowCtxCaptor = ArgumentCaptor.forClass(HttpExecutionContext.class);
+        when(connector.connect(shadowCtxCaptor.capture())).thenReturn(Completable.complete());
+
+        shadowInvoker.invoke(ctx).blockingAwait();
+
+        var shadowHeaders = shadowCtxCaptor.getValue().request().headers();
+        assertThat(shadowHeaders.get("Host")).as("client Host must not reach shadow connection").isNull();
+        assertThat(shadowHeaders.get("X-Custom")).isEqualTo("value");
+    }
+
+    @Test
+    void should_preserve_policy_configured_host_in_shadow_request() {
+        var incomingHeaders = HttpHeaders.create();
+        incomingHeaders.set("Host", "api.example.com");
+        when(request.headers()).thenReturn(incomingHeaders);
+        when(configuration.getHeaders()).thenReturn(List.of(new HttpHeader("Host", "shadow.example.com")));
+
+        var shadowCtxCaptor = ArgumentCaptor.forClass(HttpExecutionContext.class);
+        when(connector.connect(shadowCtxCaptor.capture())).thenReturn(Completable.complete());
+
+        shadowInvoker.invoke(ctx).blockingAwait();
+
+        assertThat(shadowCtxCaptor.getValue().request().headers().get("Host")).isEqualTo("shadow.example.com");
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14291

**Description**

The incoming client's `Host` header was copied verbatim into shadow request headers. The APIM-13512 fix in `HttpConnector.connect()` calls `options.setHost(customHost)` whenever a `Host` header is present in the request options — this also changes the TLS SNI. When the shadow endpoint uses HTTPS, the handshake fails because TLS SNI is set to the client's host instead of the shadow endpoint's host. The request is never sent and status stays 0.

Fix: strip the client `Host` from shadow headers in `ShadowInvoker.handleConfigHeader()`. Policy-configured `Host` headers (added afterward in the same method) are preserved and work correctly.

**Additional context**

Regression introduced by APIM-13512 fix (commit `0ebd876f83` in gravitee-api-management).
Reproduction: configure a v4 API with Traffic Shadowing Policy pointing to an HTTPS shadow endpoint — shadow requests silently fail with status 0.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.3-fix-APIM-14291-host-header-shadow-tls-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-traffic-shadowing/3.0.3-fix-APIM-14291-host-header-shadow-tls-SNAPSHOT/gravitee-policy-traffic-shadowing-3.0.3-fix-APIM-14291-host-header-shadow-tls-SNAPSHOT.zip)
  <!-- Version placeholder end -->
